### PR TITLE
Return None instead of raising "ItemNotFoundError" exception when the folder does not exist.

### DIFF
--- a/api4jenkins/__init__.py
+++ b/api4jenkins/__init__.py
@@ -73,7 +73,8 @@ class Jenkins(Item):
             <FreeStyleProject: http://127.0.0.1:8080/job/freestylejob/>
         '''
         folder, name = self._resolve_name(full_name)
-        return folder.get(name)
+        if folder.exists():
+            return folder.get(name)
 
     def iter_jobs(self, depth=0):
         '''Iterate jobs with depth


### PR DESCRIPTION
Fix #43 
Return None instead of raising "ItemNotFoundError" exception when the folder does not exist.