### PR TITLE
When creating job, create folder if not existed.

### DIFF
--- a/api4jenkins/__init__.py
+++ b/api4jenkins/__init__.py
@@ -23,6 +23,7 @@ from .view import Views
 EMPTY_FOLDER_XML = '''<?xml version='1.0' encoding='UTF-8'?>
     <com.cloudbees.hudson.plugins.folder.Folder/>'''
 
+
 class Jenkins(Item):
     r'''Constructs  :class:`Jenkins <Jenkins>`.
 

--- a/api4jenkins/__init__.py
+++ b/api4jenkins/__init__.py
@@ -120,6 +120,8 @@ class Jenkins(Item):
             <FreeStyleProject: http://127.0.0.1:8080/job/freestylejob/>
         '''
         folder, name = self._resolve_name(full_name)
+        if not folder.exists():
+            self.create_job(folder.full_name, EMPTY_FOLDER_XML)
         return folder.create(name, xml)
 
     def copy_job(self, full_name, dest):

--- a/api4jenkins/__init__.py
+++ b/api4jenkins/__init__.py
@@ -20,6 +20,8 @@ from .system import System
 from .user import User, Users
 from .view import Views
 
+EMPTY_FOLDER_XML = '''<?xml version='1.0' encoding='UTF-8'?>
+    <com.cloudbees.hudson.plugins.folder.Folder/>'''
 
 class Jenkins(Item):
     r'''Constructs  :class:`Jenkins <Jenkins>`.

--- a/api4jenkins/__init__.py
+++ b/api4jenkins/__init__.py
@@ -97,11 +97,12 @@ class Jenkins(Item):
         folder = Folder(self, self.url)
         yield from folder.iter(depth)
 
-    def create_job(self, full_name, xml):
+    def create_job(self, full_name, xml, recursive=False):
         '''Create new jenkins job with given xml configuration
 
         :param full_name: ``str``, full name of job
         :param xml: xml configuration string
+        :param recursive: (optional) Boolean, recursively create folder if not existed
 
         Usage::
 
@@ -121,7 +122,7 @@ class Jenkins(Item):
             <FreeStyleProject: http://127.0.0.1:8080/job/freestylejob/>
         '''
         folder, name = self._resolve_name(full_name)
-        if not folder.exists():
+        if recursive and not folder.exists():
             self.create_job(folder.full_name, EMPTY_FOLDER_XML)
         return folder.create(name, xml)
 

--- a/api4jenkins/__init__.py
+++ b/api4jenkins/__init__.py
@@ -21,7 +21,7 @@ from .user import User, Users
 from .view import Views
 
 EMPTY_FOLDER_XML = '''<?xml version='1.0' encoding='UTF-8'?>
-    <com.cloudbees.hudson.plugins.folder.Folder/>'''
+<com.cloudbees.hudson.plugins.folder.Folder/>'''
 
 
 class Jenkins(Item):

--- a/tests/integration/test_jenkins.py
+++ b/tests/integration/test_jenkins.py
@@ -25,9 +25,12 @@ class TestJenkins:
         with pytest.raises(BadRequestError, match=exception):
             jenkins.create_job(name, folder_xml)
 
-    def test_create_job_succ(self, jenkins, folder_xml):
-        jenkins.create_job('Level1_Folder1/new_folder', folder_xml)
-        assert jenkins.get_job('Level1_Folder1/new_folder')
+    @pytest.mark.parametrize('name, recursive', [('Level1_Folder1/new_folder', False),
+                                                 ('Level1_Folder1/Level2_Folder2/Level3_Folder1', True)],
+                             ids=['recursive=False', 'recursive=True'])
+    def test_create_job_succ(self, jenkins, folder_xml, name, recursive):
+        jenkins.create_job(name, folder_xml, recursive=recursive)
+        assert jenkins.get_job(name)
 
     def test_copy_job(self, jenkins):
         jenkins.copy_job('Level1_Folder1/Level2_Folder1', 'new_folder')


### PR DESCRIPTION
I'd like to use:
```python
j.create_job('path/to/job', xml_freestylejob)
```
instead of:
```python
j.create_job('path', xml_emptyfolder)
j.create_job('path/to', xml_emptyfolder)
j.create_job('path/to/job', xml_freestylejob)
```