### PR TITLE
ability to add extra headers while sending the request

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 Release History
 ===============
+1.14.1 (2023-07-24)
+-------------------
+- Support additional session headers 
+
 1.14 (2022-11-28)
 -----------------
 - Add AnkaCloudComputer (#70)

--- a/api4jenkins/__version__.py
+++ b/api4jenkins/__version__.py
@@ -1,5 +1,5 @@
 # encoding: utf-8
-__version__ = '1.14'
+__version__ = '1.14.1'
 __title__ = 'api4jenkins'
 __description__ = 'Jenkins Python Client'
 __url__ = 'https://github.com/joelee2012/api4jenkins'

--- a/api4jenkins/requester.py
+++ b/api4jenkins/requester.py
@@ -15,6 +15,8 @@ def Requester(**kwargs):
     # see: https://github.com/psf/requests/issues/4784
     # and https://github.com/psf/requests/issues/4664
     session = Session()
+    # headers need to be added to the session to avoid multiple 'headers' arguments while sending the request
+    session.headers.update(kwargs.pop('headers', {}))
     max_retries = kwargs.pop('max_retries', DEFAULT_MAX_RETRIES)
     adapter = adapters.HTTPAdapter(max_retries=max_retries)
     session.mount('http://', adapter)


### PR DESCRIPTION
When I'm trying to access the Jenkins instance which is behind [Google Cloud IAP with additional headers](https://cloud.google.com/iap/docs/authentication-howto#authenticating_from_proxy-authorization_header) as follows:
```python
server = Jenkins("https://jenkins.behind.iap", auth=('xxx', 'yyy'),
                 headers={"Proxy-Authorization": "Bearer zzz"})
job = server.get_job('some-job')
```

I'm getting the exception:
```
Traceback (most recent call last):
  File "/xxx/venv/lib/python3.9/site-packages/api4jenkins/item.py", line 71, in handle_req
    return self.jenkins.send_req(method, self.url + entry, **kwargs)
  File "/xxx/venv/lib/python3.9/site-packages/api4jenkins/requester.py", line 27, in send
    resp = session.request(method, url, **kwargs, **kw)
TypeError: requests.sessions.Session.request() got multiple values for keyword argument 'headers'
```
This pull request solves the problem and additional headers might be added.
