### PR TITLE
fix certificates validation, add tests requirements

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,13 @@
 Release History
 ===============
+2.0.2 (2023-11-06)
+------------------
+- Fix certificates verification after migration from `requtests` to `httpx`
+
+2.0.1 (2023-10-31)
+------------------
+- Update doc and requires python 3.8 (#94)
+
 2.0.0 (2023-10-19)
 -------------------
 - Add Async Client

--- a/api4jenkins/__version__.py
+++ b/api4jenkins/__version__.py
@@ -1,5 +1,5 @@
 # encoding: utf-8
-__version__ = '2.0.1'
+__version__ = '2.0.2'
 __title__ = 'api4jenkins'
 __description__ = 'Jenkins Python Client'
 __url__ = 'https://github.com/joelee2012/api4jenkins'

--- a/api4jenkins/http.py
+++ b/api4jenkins/http.py
@@ -31,7 +31,18 @@ def check_response(response: Response) -> None:
 
 def new_http_client(**kwargs) -> Client:
     return Client(
-        transport=HTTPTransport(retries=kwargs.pop('retries', 0)),
+        transport=HTTPTransport(
+            verify=kwargs.pop('verify', True),
+            cert=kwargs.pop('cert', None),
+            http1=kwargs.pop('http1', True),
+            http2=kwargs.pop('http2', False),
+            trust_env=kwargs.pop('trust_env', True),
+            proxy=kwargs.pop('proxy', None),
+            uds=kwargs.pop('uds', None),
+            local_address=kwargs.pop('local_address', None),
+            retries=kwargs.pop('retries', 0),
+            socket_options=kwargs.pop('socket_options', None)
+        ),
         **kwargs,
         event_hooks={'request': [log_request], 'response': [check_response]}
     )
@@ -48,7 +59,18 @@ async def async_check_response(response: Response) -> None:
 
 def new_async_http_client(**kwargs) -> AsyncClient:
     return AsyncClient(
-        transport=AsyncHTTPTransport(retries=kwargs.pop('retries', 0)),
+        transport=AsyncHTTPTransport(
+            verify=kwargs.pop('verify', True),
+            cert=kwargs.pop('cert', None),
+            http1=kwargs.pop('http1', True),
+            http2=kwargs.pop('http2', False),
+            trust_env=kwargs.pop('trust_env', True),
+            proxy=kwargs.pop('proxy', None),
+            uds=kwargs.pop('uds', None),
+            local_address=kwargs.pop('local_address', None),
+            retries=kwargs.pop('retries', 0),
+            socket_options=kwargs.pop('socket_options', None)
+        ),
         **kwargs,
         event_hooks={'request': [async_log_request],
                      'response': [async_check_response]}


### PR DESCRIPTION
It looks like after the migration from `requests` to `httpx`, skipping certificates validation has stopped working, because it looks like when `HttpTransport` is used then `verify` parameter needs to be added to [HttpTransport](https://github.com/encode/httpx/blob/master/httpx/_transports/default.py#L121) and this in Client (passed from `**kwargs`) is ignored then.


Before the change, for example script:
```python
from api4jenkins import Jenkins
client = Jenkins("https://localhost:8443", verify=False)
client.system.run_script('println("howdi")')
```

I got:
```
Traceback (most recent call last):
  File "/some/path/tests/test_jenkins.py", line 13, in test_localhost
    client.system.run_script('println("howdi")')
  File "/some/path/venv/lib/python3.11/site-packages/api4jenkins/mix.py", line 64, in run_script
    return self.handle_req('POST', 'scriptText',
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/some/path/venv/lib/python3.11/site-packages/api4jenkins/item.py", line 100, in handle_req
    self._add_crumb(self.jenkins.crumb, kwargs)
                    ^^^^^^^^^^^^^^^^^^
  File "/some/path/venv/lib/python3.11/site-packages/api4jenkins/__init__.py", line 244, in crumb
    _crumb = self._request(
             ^^^^^^^^^^^^^^
  File "/some/path/venv/lib/python3.11/site-packages/httpx/_client.py", line 814, in request
    return self.send(request, auth=auth, follow_redirects=follow_redirects)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/some/path/venv/lib/python3.11/site-packages/httpx/_client.py", line 901, in send
    response = self._send_handling_auth(
               ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/some/path/venv/lib/python3.11/site-packages/httpx/_client.py", line 929, in _send_handling_auth
    response = self._send_handling_redirects(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/some/path/venv/lib/python3.11/site-packages/httpx/_client.py", line 966, in _send_handling_redirects
    response = self._send_single_request(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/some/path/venv/lib/python3.11/site-packages/httpx/_client.py", line 1002, in _send_single_request
    response = transport.handle_request(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/some/path/venv/lib/python3.11/site-packages/httpx/_transports/default.py", line 227, in handle_request
    with map_httpcore_exceptions():
  File "/usr/lib/python3.11/contextlib.py", line 155, in __exit__
    self.gen.throw(typ, value, traceback)
  File "/some/path/venv/lib/python3.11/site-packages/httpx/_transports/default.py", line 83, in map_httpcore_exceptions
    raise mapped_exc(message) from exc
httpx.ConnectError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate (_ssl.c:1006)
```
